### PR TITLE
Suppress unhandled promise rejection while reconnect attempts

### DIFF
--- a/packages/core/monitor/index.js
+++ b/packages/core/monitor/index.js
@@ -67,7 +67,7 @@ export class Monitor {
     this.cancelReconnect()
 
     this.state = 'pending_connect'
-    this.target.connect()
+    this.target.connect().catch(err => {})
 
     return true
   }

--- a/packages/core/monitor/index.test.ts
+++ b/packages/core/monitor/index.test.ts
@@ -16,7 +16,7 @@ class TestCable implements Monitorable {
     this.emitter = createNanoEvents()
   }
 
-  connect() {}
+  async connect() {}
   disconnected(err: string | Error) {} // eslint-disable-line
   close() {}
 


### PR DESCRIPTION
Suppress unhandled promise rejection while trying to reconnect.
```connect``` method  in ```anycable-client/packages/core/cable/index.js``` is async, so it would be good idea to

1. change ```connect``` method in ```anycable-client/packages/core/monitor/index.test.ts``` to async variant
2. catch connect rejections in ```anycable-client/packages/core/monitor/index.js```


