### PR TITLE
fix: Possible unhandled promise rejection

### DIFF
--- a/packages/core/monitor/index.js
+++ b/packages/core/monitor/index.js
@@ -67,7 +67,7 @@ export class Monitor {
     this.cancelReconnect()
 
     this.state = 'pending_connect'
-    this.target.connect()
+    this.target.connect().catch(err => this.logger.info("Failed at reconnecting: " + err))
 
     return true
   }


### PR DESCRIPTION
We have encountered unhandled promise rejection warnings in ReactNative (0.63.4) whenever the anycable websocket is down.
From our investigation, it's because the reconnectNow() promise was not handled the rejection case.

Warnings happened after every `scheduleReconnect()`

![Screenshot_1631101904](https://user-images.githubusercontent.com/190798/132504953-ffec8185-77ca-4248-8df8-378508142afd.png)

With the proposing fix, it will print out the log instead of raising RN unhandled rejection warnings.
![image](https://user-images.githubusercontent.com/190798/132504979-76b04de0-5389-4cf7-af36-ab8e248f52b2.png)
