### PR TITLE
Remove unnecessary `AnyObject` type

### DIFF
--- a/packages/protobuf-encoder/index.d.ts
+++ b/packages/protobuf-encoder/index.d.ts
@@ -1,21 +1,16 @@
 import { Encoder } from '@anycable/core'
 
-interface AnyObject {
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  [key: string]: any
-}
-
 export interface MessageObject {
   command?: string
   type?: string
-  message?: AnyObject
+  message?: object
   identifier?: string
   reason?: string
   reconnect?: boolean
 }
 
 export class EnumWrapper {
-  constructor(values: AnyObject)
+  constructor(values: object)
   getIdByValue(value: string): number
   getValueById(id: number): string
 }


### PR DESCRIPTION
It seems that `AnyObject` can be replaced by plain `object`. I'd prefer to get rid of it, because having unnecessary `any` in type definitions is not very good