### PR TITLE
Make it possible to encode ArrayBuffer data.

### DIFF
--- a/packages/protobuf-encoder/index.js
+++ b/packages/protobuf-encoder/index.js
@@ -29,6 +29,10 @@ export class ProtobufEncoder {
   /* eslint-disable consistent-return */
   decode(data) {
     try {
+      if (data instanceof ArrayBuffer) {
+        data = new Uint8Array(data)
+      }
+
       let decodedMessage = Message.decode(data)
 
       // We can't skip check for presence here, since enums always have

--- a/packages/protobuf-encoder/index.test.ts
+++ b/packages/protobuf-encoder/index.test.ts
@@ -109,6 +109,25 @@ describe('decode', () => {
       expect(decoded.message).toEqual(payload)
     })
   })
+
+  describe('ArrayBuffer decoding', () => {
+    it('converts message to Uint8Array and decodes it', () => {
+      let payload = { type: 3 }
+      let encoded = Message.encode(payload).finish()
+
+      var encodedArrayBuffer = new ArrayBuffer(encoded.length);
+      var view = new Uint8Array(encodedArrayBuffer);
+
+      for (var i = 0; i < encoded.length; ++i) {
+        view[i] = encoded[i];
+      }
+
+      // @ts-ignore
+      let decoded = encoder.decode(encodedArrayBuffer) as MessageObject
+
+      expect(decoded.type).toEqual('ping')
+    })
+  })
 })
 
 describe('protobuf message e2e sending', () => {


### PR DESCRIPTION
While I was working on [this](https://github.com/anycable/anycable-rack-server/issues/9) I discovered that protobuf data is received as `ArrayBuffer`  which is not supported by protobuf.js (more info [here](https://github.com/protobufjs/protobuf.js/issues/589))