### PR TITLE
Fix: Hub entry key issue

### DIFF
--- a/packages/core/channel/index.test.ts
+++ b/packages/core/channel/index.test.ts
@@ -69,6 +69,9 @@ class TestReceiver implements Receiver {
 class TestChannel extends Channel<{ id: string }> {
   static identifier = 'test'
 }
+class AnotherTestChannel extends Channel<{ id: string }> {
+  static identifier = 'test_me_too'
+}
 
 let client: TestReceiver
 
@@ -78,6 +81,7 @@ beforeEach(() => {
 
 describe('receiver communicaton', () => {
   let channel: TestChannel
+  let anotherChannel: AnotherTestChannel
 
   beforeEach(() => {
     channel = new TestChannel({ id: '2021' })
@@ -128,6 +132,27 @@ describe('receiver communicaton', () => {
     expect(() => {
       client.subscribed()
     }).toThrow('Already connected')
+  })
+
+  it('parallel connecting', async () => {
+    anotherChannel = new AnotherTestChannel({ id: '2022' })
+
+    expect(channel.state).toEqual('disconnected')
+    expect(anotherChannel.state).toEqual('disconnected')
+
+    client.subscribe(channel)
+    client.subscribe(anotherChannel)
+
+    expect(channel.state).toEqual('connecting')
+    expect(anotherChannel.state).toEqual('connecting')
+
+    client.subscribed(channel)
+    client.subscribed(anotherChannel)
+
+    expect(channel.state).toEqual('connected')
+    expect(anotherChannel.state).toEqual('connected')
+    expect(channel.id).toBeDefined()
+    expect(anotherChannel.id).toBeDefined()
   })
 
   it('restored', () => {

--- a/packages/core/hub/index.js
+++ b/packages/core/hub/index.js
@@ -37,13 +37,12 @@ export class Hub {
   }
 
   entryFor(channel) {
-    let entry = this.entries[channel]
+    const key = JSON.stringify({ identifier: channel.identifier, params: channel.params })
 
-    if (!entry) {
-      this.entries[channel] = new Entry()
-    }
+    let entry = this.entries[key]
+    if (!entry) this.entries[key] = new Entry()
 
-    return this.entries[channel]
+    return this.entries[key]
   }
 
   add(id, channel) {

--- a/packages/core/hub/index.js
+++ b/packages/core/hub/index.js
@@ -37,7 +37,10 @@ export class Hub {
   }
 
   entryFor(channel) {
-    const key = JSON.stringify({ identifier: channel.identifier, params: channel.params })
+    let key = JSON.stringify({
+      identifier: channel.identifier,
+      params: channel.params
+    })
 
     let entry = this.entries[key]
     if (!entry) this.entries[key] = new Entry()


### PR DESCRIPTION
Hi!

Small problem description:
We have two channels in our projects now: `NotificationChannel` and `ConversationChannel`.
I've faced a problem with parallel subscriptions to both of this channels on page loading on messages page.

After some debug I realized, that for both of channel entries Hub uses same key: `[object Object]` :D
So in this PR I've added simple key generation (stringified object of channel identifier and params) and it even must be uniq.

Also added new test case