### PR TITLE
Un-type `received` data argument

### DIFF
--- a/packages/core/create-cable/index.d.ts
+++ b/packages/core/create-cable/index.d.ts
@@ -4,7 +4,7 @@ import { Encoder } from '../encoder/index.js'
 import { Monitor, ReconnectStrategy } from '../monitor/index.js'
 import { Cable } from '../cable/index.js'
 import { Protocol } from '../protocol/index.js'
-import { Channel, Message, ChannelParamsMap } from '../channel/index.js'
+import { Channel, ChannelParamsMap } from '../channel/index.js'
 
 export type ProtocolID =
   | 'actioncable-v1-json'
@@ -49,7 +49,7 @@ export type ActionCableMixin = Partial<{
   initialized: () => void
   connected: () => void
   rejected: () => void
-  received: (data: Message) => void
+  received: (data: any) => void
   disconnected: () => void
 }>
 


### PR DESCRIPTION
The received function is only passed around in the library, I think the `data` arg shouldn't be typed.

In my application code, I can then make it a stronger type. Like a subset of object, say:

```ts
interface MyMessage {
  payload: {
    whatever: number,
    i_want: string
  },
  type: MyEnum
}

// app code

consumer = createConsumer('ws://whatever.com')

const received = (message: MyMessage) => {
  // do stuff
}

consumer.subscriptions.create(channel, { received })
```

Before this change, I can't do that, because this `MyMessage` is incompatible with `Message`.