### PR TITLE
Omit `undefined` within Channels' params to fix invalid JSON serialization

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+- Omit `undefined` within Channels' params to fix invalid JSON serialization. ([@ardecvz][])
+
+It's intended to mimic the ActionCable behavior when using `JSON.stringify`.
+
+Also, extend the type signature to allow `null` values.
+
 ## 0.7.11 (2023-11-29)
 
 - Implement `subscriptions.findAll` for Action Cable compat. ([@palkan][])
@@ -183,3 +189,4 @@ Each component takes care of subscribing and unsubsribing; the actual subscripti
 [@gydroperit]: https://github.com/gydroperit
 [@TheSeally]: https://github.com/TheSeally
 [@lokkirill]: https://github.com/lokkirill
+[@ardecvz]: https://github.com/ardecvz

--- a/packages/core/stringify-params/index.d.ts
+++ b/packages/core/stringify-params/index.d.ts
@@ -1,3 +1,3 @@
-type Params = { [token: string]: boolean | number | string }
+type Params = { [token: string]: boolean | number | string | null | undefined }
 
 export function stringifyParams(params: Params | void | null): string

--- a/packages/core/stringify-params/index.js
+++ b/packages/core/stringify-params/index.js
@@ -3,6 +3,7 @@ export function stringifyParams(params) {
 
   let parts = Object.keys(params)
     .sort()
+    .filter(k => params[k] !== undefined)
     .map(k => {
       let v = JSON.stringify(params[k])
       return `${JSON.stringify(k)}:${v}`

--- a/packages/core/stringify-params/index.test.ts
+++ b/packages/core/stringify-params/index.test.ts
@@ -9,3 +9,7 @@ it('handles nulls and undefined', () => {
   expect(stringifyParams(null)).toEqual('')
   expect(stringifyParams(undefined)).toEqual('')
 })
+
+it('omits undefined and handles null within params', () => {
+  expect(stringifyParams({ x: undefined, b: null })).toEqual('{"b":null}')
+})


### PR DESCRIPTION
- Omit `undefined` within Channels' params to fix invalid JSON serialization
It's intended to mimic the ActionCable behavior when using [`JSON.stringify`](https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/subscription.js#L72).

Projects currently migrating from the standard ActionCable client can use optional arguments when creating Channels:
```js
// A simplified example
import { createConsumer } from '@anycable/web';

function createChannelForOnlineUsersOnPage(path, id) {
  createConsumer.subscriptions.create(
    {
      channel: 'OnlineUsersChannel',
      path: path,
      id: id,
    },
    ...
  )
}

createChannelForOnlineUsersOnPage('index')
createChannelForOnlineUsersOnPage('show', 1)
```
Without the change in PR, JSON is serialized incorrectly:
```json
{"command":"subscribe","identifier":"{\"channel\":\"OnlineUsersChannel\",\"id\":undefined,\"path\":\"/index\"}}
```
As a result, this leads to a failure during JSON deserialization in AnyCable Go:
```
Command response: error_msg:"unexpected token at '{\"channel\":\"OnlineUsersChannel\",\"id\":undefined,\"path\":\"/index\"'
```
---
- Also, extend the type signature to allow `null` values.
It's a more controversial change as type checking will no longer catch `undefined` and `null` values, but it seems that there's no limitation on the ActionCable side.
Therefore, users can rely on passing explicit `null` within params (technically, it's possible to pass Objects and Arrays in JSON as well, but I'm uncertain whether allowing these two is practical too).
