### PR TITLE
Add conditional check to prevent redefining existing custom stream source element

### DIFF
--- a/packages/turbo-stream/start.js
+++ b/packages/turbo-stream/start.js
@@ -12,7 +12,9 @@ export function start(cable, opts = {}) {
   C.cable = cable
   C.channelClass = channelClass
 
-  customElements.define(tagName, C)
+  if (customElements.get(tagName) === undefined) {
+    customElements.define(tagName, C)
+  }
 
   if (opts.requestSocketIDHeader) {
     let headerName =


### PR DESCRIPTION
This Pull Request introduces a safeguard in the `start.js` file to prevent the redefinition of existing custom elements. The issue was observed when legacy JQuery `page-refresh` events or jest-dom testing caused anycable to reinitiate the start function. This led to an unnecessary re-triggering of the custom stream element definition, even when the element was already present in the window.

The proposed solution involves a conditional check before defining the custom element:
```js
if (customElements.get(tagName) === undefined) {
  customElements.define(tagName, C)
}
```

This approach is consistent with the convention used in the hotwired turbo library. 