### PR TITLE
fix(web): bump web to 0.9.1

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anycable/web",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AnyCable JavaScript client for web",
   "keywords": [
     "anycable",
@@ -21,6 +21,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@anycable/core": "^0.9.0"
+    "@anycable/core": "^0.9.1"
   }
 }


### PR DESCRIPTION
Right now if you install `anycable/web` it installs with the `anycable/core` version `0.9.0` but there is fixes which come at `0.9.1`