### PR TITLE
ActionCableSubscription#perform now returns a promise

### DIFF
--- a/packages/core/create-cable/index.d.ts
+++ b/packages/core/create-cable/index.d.ts
@@ -84,7 +84,7 @@ export class ActionCableSubscription {
   channel: ActionCableChannel
   identifier: string
 
-  perform(action: string, payload?: object): void
+  perform(action: string, payload?: object): Promise<void>
   send(payload: object): void
   unsubscribe(): void
 }

--- a/packages/core/create-cable/index.js
+++ b/packages/core/create-cable/index.js
@@ -199,7 +199,7 @@ class ActionCableSubscription {
   }
 
   perform(action, data = {}) {
-    this.channel.perform(action, data)
+    return this.channel.perform(action, data)
   }
 
   send(data) {


### PR DESCRIPTION
So this deviates from the ActionCable JS client a where it returns a boolean:
https://github.com/rails/rails/blob/242216803ee73f528b0a74c6bdb367e5b98d8f83/actioncable/app/assets/javascripts/action_cable.js#L318

Long trace of ActionCable.Subscriptions -> ActionCable.Consumer: https://github.com/rails/rails/blob/242216803ee73f528b0a74c6bdb367e5b98d8f83/actioncable/app/assets/javascripts/action_cable.js#L140

But for our purposes, we noticed sometimes AnyCable's ActionCableSubscription#perform is called on a closed subscription and raises an error (should now be adjustable in 0.9.2 thanks!), but it would be nice to catch and handle those errors.

Channel#perform already surfaces the promise, so why not just surface it one more level?
https://github.com/anycable/anycable-client/blob/62674a8207b6add893677369106766c7baa234f4/packages/core/channel/index.js#L120