### PR TITLE
Add whisper to the top-level compat interface

### DIFF
--- a/packages/core/action_cable_compat/index.d.ts
+++ b/packages/core/action_cable_compat/index.d.ts
@@ -16,6 +16,7 @@ export class ActionCableSubscription {
 
   perform(action: string, payload?: object): void
   send(payload: object): void
+  whisper(payload: object): void
   unsubscribe(): void
 }
 

--- a/packages/core/action_cable_compat/index.js
+++ b/packages/core/action_cable_compat/index.js
@@ -22,7 +22,7 @@ export class ActionCableSubscription {
   }
 
   whisper(data) {
-    this.channel.whisper(data)
+    return this.channel.whisper(data)
   }
 
   get identifier() {

--- a/packages/core/action_cable_compat/index.js
+++ b/packages/core/action_cable_compat/index.js
@@ -21,6 +21,10 @@ export class ActionCableSubscription {
     this.channel.send(data)
   }
 
+  whisper(data) {
+    this.channel.whisper(data)
+  }
+
   get identifier() {
     return this.channel.identifier
   }


### PR DESCRIPTION
* Otherwise when using compat, accessing whisper is very awkward. ie, if you have `channel = this.consumer.subscriptions.create`, you then need to call `channel.channel.whisper`

* With this change, you can call `channel.whisper` instead

This was inspired by this addition to the yrb-actioncable package, which came across as odd and confusing: https://github.com/y-crdt/yrb-actioncable/pull/180/files
