### PR TITLE
Fix channels being dropped when a subscribe races a socket close

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## master
 
+- Fix channels being permanently dropped when a subscribe races a socket close.
+
+  `Cable#send` now raises a `DisconnectedError` when the transport refuses to
+  send, so `Cable#subscribe` retries on reconnect instead of treating the
+  failure as fatal and unsubscribing the channel from the hub. The Action Cable
+  protocol also drops the pending subscription it recorded before the failed
+  send, which previously made every later subscribe for that identifier fail
+  with "Already subscribing".
+
 ## 1.1.6 (2026-02-13)
 
 - Fix parsing empty presence sets.

--- a/packages/core/action_cable/index.js
+++ b/packages/core/action_cable/index.js
@@ -62,7 +62,16 @@ export class ActionCableProtocol {
         id
       }
 
-      this.cable.send(this.buildSubscribeRequest(identifier))
+      try {
+        this.cable.send(this.buildSubscribeRequest(identifier))
+      } catch (err) {
+        // Nothing was sent, so no ack is coming and the retry/expire timers
+        // below are never armed. Drop the pending entry we just recorded --
+        // otherwise it outlives the failure and every later subscribe for this
+        // identifier is rejected with "Already subscribing".
+        delete this.pendingSubscriptions[identifier]
+        throw err
+      }
 
       this.maybeRetrySubscribe(id, identifier, retryInterval)
     })

--- a/packages/core/action_cable/index.test.ts
+++ b/packages/core/action_cable/index.test.ts
@@ -105,6 +105,28 @@ describe('subscriptions', () => {
     return res
   })
 
+  it('does not leave a pending subscription behind when the send fails', async () => {
+    cable.sendError = Error('WebSocket is not connected')
+
+    await expect(protocol.subscribe('TestChannel')).rejects.toThrow(
+      'WebSocket is not connected'
+    )
+
+    // Nothing was sent, so no ack and no retry/expire timers are coming. The
+    // pending entry must not survive, otherwise this identifier can never be
+    // subscribed again on this protocol instance.
+    cable.sendError = undefined
+
+    let res = expect(protocol.subscribe('TestChannel')).resolves.toEqual(
+      identifier
+    )
+
+    expect(cable.mailbox).toHaveLength(1)
+    protocol.receive({ type: 'confirm_subscription', identifier })
+
+    return res
+  })
+
   it('subscribes successfully with params', () => {
     identifier = JSON.stringify({
       channel: 'TestChannel',

--- a/packages/core/cable/index.js
+++ b/packages/core/cable/index.js
@@ -316,7 +316,21 @@ export class Cable {
 
     this.logger.debug('outgoing message', msg)
 
-    this.transport.send(data)
+    try {
+      this.transport.send(data)
+    } catch (err) {
+      // The transport refuses to send when its socket is already gone, but the
+      // cable may not have processed the close event yet (e.g. the tab was
+      // starved of CPU long enough for the server to drop the connection).
+      // Surface that as a DisconnectedError so callers can tell "we are not
+      // connected right now, retry on reconnect" apart from a genuine failure.
+      // Without it, Cable#subscribe treats the plain Error as fatal and
+      // permanently removes the channel from the hub, so it is never
+      // re-subscribed when the connection comes back.
+      throw err instanceof ReasonError
+        ? err
+        : new DisconnectedError(err, 'transport_closed')
+    }
   }
 
   keepalive(msg) {

--- a/packages/core/cable/index.test.ts
+++ b/packages/core/cable/index.test.ts
@@ -751,6 +751,49 @@ describe('channels', () => {
     ).rejects.toEqual(new ReasonError(Error('failed')))
   })
 
+  it('send wraps a transport failure into a DisconnectedError', () => {
+    transport.sendError = Error('WebSocket is not connected')
+
+    expect(() => {
+      cable.send({ action: 'ping' })
+    }).toThrow(DisconnectedError)
+  })
+
+  it('subscribe keeps the channel when the transport send fails', async () => {
+    // A protocol that sends over the cable, like ActionCableProtocol does
+    let attempts = 0
+    jest.spyOn(protocol, 'subscribe').mockImplementation(async identifier => {
+      attempts++
+      cable.send({ command: 'subscribe', identifier })
+      return 'test_id'
+    })
+
+    // The socket is already gone but the cable hasn't processed the close yet,
+    // so the transport rejects the send with a plain Error. That must not be
+    // treated as a fatal subscribe failure: the channel has to stay in the hub
+    // so it is re-subscribed once the connection is back.
+    transport.sendError = Error('WebSocket is not connected')
+
+    cable.subscribe(channel)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(attempts).toEqual(1)
+    expect(channel.state).not.toEqual('closed')
+    expect(cable.hub.subscriptions.all()).toHaveLength(1)
+    expect(logger.errors).toHaveLength(0)
+
+    // Reconnect and the pending subscription goes through
+    transport.sendError = undefined
+    cable.disconnected(new DisconnectedError('test'))
+    await Promise.resolve()
+    cable.connect()
+    cable.connected()
+
+    await channel.ensureSubscribed()
+    expect(channel.state).toEqual('connected')
+    expect(cable.hub.size).toEqual(1)
+  })
+
   it('unsubscribe when connected', async () => {
     await cable.subscribe(channel).ensureSubscribed()
     expect(cable.hub.size).toEqual(1)

--- a/packages/core/protocol/testing.ts
+++ b/packages/core/protocol/testing.ts
@@ -33,7 +33,12 @@ export class TestConsumer implements Consumer {
     }
   }
 
+  // When set, send() throws it instead of recording the message — mimics a
+  // cable whose transport is already gone
+  sendError?: Error
+
   send(msg: object) {
+    if (this.sendError) throw this.sendError
     this.mailbox.push(msg)
   }
 

--- a/packages/core/transport/testing.ts
+++ b/packages/core/transport/testing.ts
@@ -10,6 +10,9 @@ export class TestTransport implements Transport<string> {
   state: Env
   opened: boolean
   sent: (string | Uint8Array)[]
+  // When set, send() throws it instead of recording the payload — mimics a
+  // real transport whose socket is already gone
+  sendError?: Error
 
   constructor(url: string = '') {
     this.url = url
@@ -42,6 +45,7 @@ export class TestTransport implements Transport<string> {
   }
 
   send(data: string | Uint8Array) {
+    if (this.sendError) throw this.sendError
     this.sent.push(data)
   }
 


### PR DESCRIPTION
Note: This was observed during [COSMOS](https://github.com/openc3/cosmos) testing. I had Claude create this PR based on a similar fix we made to our code. Let me know if you have any questions. As usual per Claude, this writeup is a little verbose but it fixes real issues.

## Problem

When the WebSocket has closed but the cable hasn't processed the close event yet — e.g. a background tab starved of CPU long enough for the server to drop the connection — `WebSocketTransport#send` throws a plain `Error('WebSocket is not connected')`.

`Cable#subscribe` only recognizes `DisconnectedError` as "retry on connect":

```js
if (err instanceof DisconnectedError) {
  this.logger.debug('disconnected during subscription; will retry on connect', channelMeta)
  lock.release()
  return
}

this.logger.error('failed to subscribe', { error: err, ...channelMeta })
```

So the plain `Error` takes the fatal branch: `subscription.close(err)` + `this.hub.unsubscribe(identifier)`. The channel is gone for good and is never re-subscribed when the connection comes back, leaving the caller waiting on events that never arrive.

There's a second, compounding issue. `ActionCableProtocol#subscribe` records the subscription as pending *before* the send, and the retry/expire timers are armed *after* it:

```js
this.pendingSubscriptions[identifier] = { resolve, reject, id }

this.cable.send(this.buildSubscribeRequest(identifier))

this.maybeRetrySubscribe(id, identifier, retryInterval)
```

If the send throws, nothing ever expires that entry. Until the protocol is reset, every later subscribe for the identifier is rejected with `Error('Already subscribing')` — itself a plain `Error`, so it kills the channel the same way.

We hit this in [OpenC3 COSMOS](https://github.com/OpenC3/cosmos): a tool attaching to a long-running server-side script would sit on "Connecting…" indefinitely after the tab had been backgrounded.

## Fix

- `Cable#send` converts a transport failure into a `DisconnectedError`, so every caller that classifies errors treats it as "not connected right now" rather than a genuine failure. Errors that are already a `ReasonError` pass through unchanged.
- `ActionCableProtocol#subscribe` drops the pending entry it just recorded when the send throws.

## Tests

Three regression tests, each verified to fail without its corresponding fix:

- `cable`: `send` wraps a transport failure into a `DisconnectedError`
- `cable`: a subscribe whose send fails keeps the channel in the hub and completes on reconnect
- `action_cable`: a failed send leaves no pending subscription behind, so the identifier can be subscribed again

Adds a `sendError` hook to `TestTransport` and `TestConsumer` to simulate a transport whose socket is already gone.

Full suite passes (382 tests), plus `tsc`, eslint and prettier.

Happy to drop the CHANGELOG entry if you'd rather write that yourselves.