### PR TITLE
Expose @anycable/core/testing via package exports

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix importing `@anycable/core/testing`: the `./testing` subpath was missing from the package `exports`, so Node ESM, Vite, and Jest 28+ failed to resolve it. ([@irinanazarova][])
+
 ## 1.1.6 (2026-02-13)
 
 - Fix parsing empty presence sets.
@@ -273,3 +275,4 @@ Each component takes care of subscribing and unsubsribing; the actual subscripti
 [@ardecvz]: https://github.com/ardecvz
 [@cmdoptesc]: https://github.com/cmdoptesc
 [@d4rky-pl]: https://github.com/d4rky-pl
+[@irinanazarova]: https://github.com/irinanazarova

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": "./index.js",
+    "./testing": "./testing/index.js",
     "./package.json": "./package.json"
   },
   "dependencies": {


### PR DESCRIPTION
The `exports` map omits the `./testing` subpath, so `import { TestCable } from '@anycable/core/testing'` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` under Node ESM, Vite, and Jest 28+ (reproduced on a clean install of v1.1.6); adding the subpath fixes the resolution.